### PR TITLE
logging prompts to s3 via fastapi

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import replicate
+import requests
 import streamlit as st
 from streamlit.logger import get_logger
 
@@ -14,6 +15,9 @@ st.markdown(
     "Built by [Nirant Kasliwal](https://nirantk.com/about/). Sponsored by [The GenerativeAI Community 🇮🇳](https://nirantk.com/community)"
 )
 os.environ["REPLICATE_API_TOKEN"] = st.secrets["REPLICATE_API_TOKEN"]
+fastapi_endpoint = st.secrets["FASTAPI_ENDPOINT"]
+secret_token = st.secrets["SECRET_TOKEN"] # Token for FastAPI endpoint authentication to log queries
+
 llama_family = {
     "Llama7B-v2-Chat": "a16z-infra/llama7b-v2-chat:4f0a4744c7295c024a1de15e1a63c880d3da035fa1f49bfd344fe076074c8eea",
     "Llama13B-v2-Chat": "a16z-infra/llama13b-v2-chat:df7690f1994d94e96ad9d568eac121aecf50684a0b0963b25a41cc40061269e5",
@@ -69,6 +73,12 @@ if prompt := st.chat_input("What is up?"):
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
         st.markdown(prompt)
+        # Logging to FastAPI Endpoint
+        headers = {"Authorization": f"Bearer {secret_token}"}
+        log_data = {"log": f"User Query: {prompt}"}
+        response = requests.post(fastapi_endpoint, json=log_data, headers=headers)
+        if response.status_code == 200:
+            logger.info("Query logged successfully")
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()

--- a/logs3/Dockerfile
+++ b/logs3/Dockerfile
@@ -1,0 +1,18 @@
+# https://hub.docker.com/_/python
+FROM python:3.9.16-slim-bullseye
+
+ENV PYTHONUNBUFFERED True
+
+RUN pip install --upgrade pip
+
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/logs3/main.py
+++ b/logs3/main.py
@@ -1,0 +1,68 @@
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+from fastapi import FastAPI, Depends, FastAPI, HTTPException
+from loguru import logger
+from pydantic import BaseModel
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+app = FastAPI()
+security = HTTPBearer()
+
+
+class LogItem(BaseModel):
+    log: str
+
+
+# Replace with your S3 credentials and bucket name
+AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY")
+AWS_SECRET_KEY = os.environ.get("AWS_SECRET_KEY")
+S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "llamachatlogs")
+S3_FILE_NAME = os.environ.get("S3_FILE_NAME", "llama-chat.txt")
+SECRET_TOKEN = os.environ.get("SECRET_TOKEN")
+
+s3_client = boto3.client(
+    "s3", aws_access_key_id=AWS_ACCESS_KEY, aws_secret_access_key=AWS_SECRET_KEY
+)
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    if token != SECRET_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return True
+
+@app.post("/log")
+async def log_to_s3(log_item: LogItem, authenticated: bool = Depends(verify_token)):
+    # Request body should be in the format {"log": "A new log line from llama-chat"}
+    log_line = log_item.log
+
+    if not log_line:
+        return {"message": "No log provided."}
+
+    # Read the existing file from S3
+    try:
+        logger.info("Fetched existing log from S3.")
+        existing_log = s3_client.get_object(Bucket=S3_BUCKET_NAME, Key=S3_FILE_NAME)
+        existing_log_contents = existing_log["Body"].read().decode("utf-8")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            logger.info("No existing log found in S3.")
+            existing_log_contents = ""
+
+    # Concatenate the new log with the existing content
+    updated_log_contents = existing_log_contents + log_line + "\n"
+
+    # Replace the previous file with the new file to S3
+    try:
+        s3_client.put_object(
+            Bucket=S3_BUCKET_NAME,
+            Key=S3_FILE_NAME,
+            Body=updated_log_contents.encode("utf-8"),
+            ACL="bucket-owner-full-control",
+        )
+        logger.info(f"Log appended to S3: {log_line}")
+        return {"message": "Log appended to S3 successfully."}
+    except Exception as e:
+        logger.error(f"Error appending log to S3: {e}")
+        return {"message": "Error appending log to S3.", "error": str(e)}

--- a/logs3/requirements.txt
+++ b/logs3/requirements.txt
@@ -1,0 +1,4 @@
+uvicorn
+fastapi
+boto3
+loguru


### PR DESCRIPTION
Streamlit queries logged to S3 via fastapi. To prevent misuse, a basic authentication is implemented with a secret_token that is shared between streamlit and the fastapi server.

Open to inputs/suggestions